### PR TITLE
makes bloc more npm friendly.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.{js,sol}]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+end_of_line = lf
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ cabal.sandbox.config
 *.aux
 *.hp
 *.~
+node_modules/

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Minimal commandline build and deploy tool for the blockapps api
 ## Installation
 
 ``` 
-$ git clone https://github.com/blockapps/bloc.git
-$ ./install.sh
+$ npm install -g blockapps/bloc
 ```
 
 ## Demo

--- a/bin/main.js
+++ b/bin/main.js
@@ -2,12 +2,13 @@
 
 var main = function() {
 
-    var sc = require('../lib/scaffold.js');  
+    var sc = require('../lib/scaffold.js');
     var cmd = require('../lib/cmd.js');
     var yamlConfig = require('../lib/yaml-config.js');
     var cmdArr = cmd.argv._;
     var compile = require('../lib/compile.js');
     var fs = require('fs');
+    var path = require('path');
     var prompt = require('prompt');
     var createPassword = require('../lib/prompt-schema.js').createPassword;
     var requestPassword = require('../lib/prompt-schema.js').requestPassword;
@@ -15,35 +16,44 @@ var main = function() {
     var key = require('../lib/keygen');
     var request = require('request');
     var upload = require('../lib/upload.js');
-    var register = require('../lib/register');    
-   
+    var register = require('../lib/register');
+
     var scaffold = (cmd.argv.s !== undefined);
     switch(cmdArr[0]) {
-    case 'compile': 
+    case 'compile':
         console.log("compiling sources");
         if (cmdArr[1] === undefined) {
             // compile all files
+            var solSrcDir = path.normalize('./contracts');
             var config = yamlConfig.readYaml('config.yaml')
-            var dir = fs.readdirSync('contracts').filter(function(t) { 
-                var splitStr = t.split('.'); // maybe should use regex
-                return splitStr[splitStr.length-1] == 'sol';
-            }
-                                                        );
-            var dirPath = dir.map(function (t) { return 'contracts/' + t; });
-            var solSrc = dirPath.map(function (t) { console.log(t); return fs.readFileSync(t).toString() });
+            var srcFiles = fs.readdirSync(solSrcDir).filter(function(filename) {
+                return path.extname(filename) === '.sol';
+            });
+            var solSrc = srcFiles.map(function (filename) {
+                console.log(path.join(solSrcDir, filename));
+                return fs.readFileSync(path.join(solSrcDir, filename)).toString()
+            });
 
             compile.compileSol(solSrc,config.apiURL,scaffold,config.appName);
         }
-        else { 
-            // compile < filename > 
-
+        else if (cmdArr[1] && path.parse(cmdArr[1]).ext === '.sol') {
+            // compile < filename >
+            console.log('compiling single file: ' + cmdArr[1]);
+            try {
+                console.log(cmdArr[1])
+                var config = yamlConfig.readYaml('config.yaml')
+                var contents = fs.readFileSync(cmdArr[1]);
+                compile.compileSol([contents], config.apiURL, scaffold, config.appName);
+            } catch (e) {
+                console.error(e);
+            }
         }
         break;
 
       case 'upload':
 //          console.log("uploading sources");
-        
-//          var dir = fs.readdirSync('contracts').filter(function(t) { 
+
+//          var dir = fs.readdirSync('contracts').filter(function(t) {
 //                var splitStr = t.split('.'); // maybe should use regex
 //                return splitStr[splitStr.length-1] == 'sol';
 //              }
@@ -56,7 +66,7 @@ var main = function() {
             console.log("contract name required");
             break;
         }
-	var config = yamlConfig.readYaml('config.yaml');
+        var config = yamlConfig.readYaml('config.yaml');
         var store = key.readKeystore();
         var address = store.addresses[0];
 
@@ -86,15 +96,15 @@ var main = function() {
 
       case 'init':
          // if (cmdArr[1] === undefined) { console.log("project name required"); break; }
-         
+
          prompt.start();
          prompt.get(scaffoldApp, function(err,result) {
-            sc.createDirScaffold(result.appName); 
-            yamlConfig.writeYaml(result.appName + "/config.yaml",result);           
+            sc.createDirScaffold(result.appName);
+            yamlConfig.writeYaml(result.appName + "/config.yaml", result);
           });
-         
+
          break;
-          
+
       default:
          console.log("unrecognized command");
     }

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-npm install https://github.com/blockapps/blockapps-js.git
-npm install ethlightjs
-npm install
-npm link

--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -1,6 +1,7 @@
 
 module.exports.createDirScaffold = function(projectName) {
   var fs = require('fs');
+  var path = require('path');
   var stat;
 
   try {
@@ -11,72 +12,21 @@ module.exports.createDirScaffold = function(projectName) {
 
   if (stat !== undefined) { console.log("project: " + projectName + " already exists"); return; }
   else {
-   var simpleStorageString = "contract SimpleStorage {\n" +
-    "  uint storedData;\n" + 
-    "  function set(uint x) {\n" + 
-    "    storedData = x;\n" + 
-    "  }\n" +
-    "  function get() returns (uint retVal) {\n" + 
-    "    return storedData;\n" +
-    "  }\n" +
-    "}"; 
+    var projectAbsolutePath = path.resolve(projectName);
+    var projectFolders = ['js', 'html', 'css', 'routes', 'contracts', 'meta'];
 
-    var simpleMultiSigString = "contract SimpleMultiSig {\n" + 
-     "address alice1;\n" +
-     "address alice2;\n" +
-     "address bob;\n" + 
-     "uint numSigned = 0;\n" +
-     "bytes32 error;\n" + 
-     "bool registeredYet;\n" +   
-     "mapping (address => bool) signedYet;\n\n"+ 
-     "function SimpleMultiSig() {\n" + 
-     "  bob = msg.sender;\n" +
-     "  registeredYet = false;\n" + 
-     "}\n\n" +
-     "function register(address registerAlice1, address registerAlice2) {\n" +
-     "  if (msg.sender == bob && registeredYet == false) {\n" +
-       "    alice1 = registerAlice1;\n" +
-       "    alice2 = registerAlice2;\n" +
-       "    registeredYet = true;\n" +
-     "  } else if (msg.sender == bob) {\n" +
-       '    error = "registered already";\n' +
-     "  } else {\n" +
-     '    error = "you are not bob!";\n' +
-     "  }\n" +
-   "}\n\n" +
-   "function withdraw(address to) {\n" +
-   "  if ((msg.sender == alice1 || msg.sender == alice2) && numSigned >= 2) {\n" +
-   "     to.send(this.balance);\n" + 
-   "     numSigned = 0;\n" +
-   "    signedYet[alice1] = signedYet[alice2] = signedYet[bob] = false;\n" +
-   "  } else {\n" +
-   '     error = "cannot withdraw yet!";\n' +
-   "  }\n" +
-   "}\n\n" +
-   "function addSignature() {\n" +
-   "  if (msg.sender == alice1 && signedYet[alice1]==false) {\n" + 
-   "    signedYet[alice1] = true;\n" +
-   "    numSigned++;\n" + 
-   "  } else if (msg.sender == alice2 && signedYet[alice2]==false) {\n" + 
-   "    signedYet[alice2] = true;\n" +
-   "    numSigned++;\n" +
-   "  } else if (msg.sender == bob && signedYet[bob]==false) {\n" + 
-   "    signedYet[bob] = true;\n" + 
-   "    numSigned++;\n" +
-   "  } else {\n" +
-   "    error = 'unknown address';\n" +
-   "  }\n"+ 
-   "}\n"+
-   "}\n";
- 
-   fs.mkdirSync(projectName + '/js/');
-   fs.mkdirSync(projectName + '/html/');
-   fs.mkdirSync(projectName + '/css/');
-   fs.mkdirSync(projectName + '/routes/');
-   fs.mkdirSync(projectName + '/contracts/');
-   fs.mkdirSync(projectName + '/meta/');
-   fs.writeFileSync(projectName + '/contracts/SimpleStorage.sol', simpleStorageString);
-   fs.writeFileSync(projectName + '/contracts/SimpleMultiSig.sol', simpleMultiSigString);
+    var templatesFolder = path.normalize(path.join(__dirname, '..', 'templates'));
+    var contractTemplates = fs.readdirSync(path.join(templatesFolder, 'sol'));
 
+    projectFolders.forEach(function(folderName, index) {
+       fs.mkdirSync(path.join(projectAbsolutePath, folderName));
+    });
+
+
+    contractTemplates.forEach(function(filename, index){
+        var templateStream = fs.createReadStream(path.join(templatesFolder, 'sol', filename));
+        var writeStream = fs.createWriteStream(path.join(projectAbsolutePath, 'contracts', filename));
+        templateStream.pipe(writeStream);
+    });
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
   },
   "dependencies": {
     "bignumber.js": "^2.0.7",
+    "blockapps-js": "blockapps/blockapps-js",
     "enum": "^2.1.0",
     "ethereumjs-tx": "^0.5.9",
     "ethereumjs-util": "^1.3.6",
+    "ethlightjs": "file:ethlightjs",
     "js-yaml": "^3.3.1",
     "prompt": "^0.2.14",
     "request": "^2.60.0",

--- a/templates/sol/SimpleMultiSig.sol
+++ b/templates/sol/SimpleMultiSig.sol
@@ -1,0 +1,51 @@
+contract SimpleMultiSig {
+     address alice1;
+     address alice2;
+     address bob;
+     uint numSigned = 0;
+     bytes32 error;
+     bool registeredYet;
+     mapping (address => bool) signedYet;
+
+     function SimpleMultiSig() {
+       bob = msg.sender;
+       registeredYet = false;
+     }
+
+     function register(address registerAlice1, address registerAlice2) {
+       if (msg.sender == bob && registeredYet == false) {
+           alice1 = registerAlice1;
+           alice2 = registerAlice2;
+           registeredYet = true;
+       } else if (msg.sender == bob) {
+           error = "registered already";
+       } else {
+         error = "you are not bob!";
+       }
+   }
+
+   function withdraw(address to) {
+     if ((msg.sender == alice1 || msg.sender == alice2) && numSigned >= 2) {
+        to.send(this.balance);
+        numSigned = 0;
+       signedYet[alice1] = signedYet[alice2] = signedYet[bob] = false;
+     } else {
+        error = "cannot withdraw yet!";
+     }
+   }
+
+   function addSignature() {
+     if (msg.sender == alice1 && signedYet[alice1]==false) {
+       signedYet[alice1] = true;
+       numSigned++;
+     } else if (msg.sender == alice2 && signedYet[alice2]==false) {
+       signedYet[alice2] = true;
+       numSigned++;
+     } else if (msg.sender == bob && signedYet[bob]==false) {
+       signedYet[bob] = true;
+       numSigned++;
+     } else {
+       error = 'unknown address';
+     }
+   }
+}

--- a/templates/sol/SimpleStorage.sol
+++ b/templates/sol/SimpleStorage.sol
@@ -1,0 +1,9 @@
+contract SimpleStorage {
+    uint storedData;
+    function set(uint x) {
+        storedData = x;
+    }
+    function get() returns (uint retVal) {
+        return storedData;
+    }
+}


### PR DESCRIPTION
- removed install.sh. use npm -g if you choose to make the command available globally (npm install -g blocapps/bloc).
- moved scaffolding contracts into template files.
- made path handling more safe.
 - added capability to compile single contract at a time  (useful for tools that watch the filesystem for changes and auto recompile).
- added editorconfig file for whitespace/tab handling.