### PR TITLE
Fixing mis-named Array to be called Stake

### DIFF
--- a/templates/app/contracts/Stake.sol
+++ b/templates/app/contracts/Stake.sol
@@ -1,4 +1,4 @@
-contract Array {
+contract Stake {
   mapping (address => uint) stake; // percentages by address (basically)
   address[] stakeHolders; // to iterate over
   address holdingTheBag; // last arrival to the party


### PR DESCRIPTION
One of the sample contracts is named `Array`. But if you look at the actual code, it should be named `Stake`.