### PR TITLE
Changed from localhost to 0.0.0.0 in app.js so bloc server can work with vagrant.

### DIFF
--- a/templates/app.js
+++ b/templates/app.js
@@ -43,7 +43,7 @@ app.use('/static', express.static('app/static'));
 app.use('/images', express.static('images'));
 
 var port = process.env.PORT || 8000;
-var host = process.env.HOST || 'localhost';
+var host = process.env.HOST || '0.0.0.0';
 
 var config = yaml.safeLoad(fs.readFileSync('config.yaml'));
 var apiURI = config.apiURL;


### PR DESCRIPTION
Do you see any issue using 0.0.0.0? Localhost still works and this allows bloc server to run on vagrant. @kjameslubin 