### PR TITLE
Prevents `bloc` from crashing on bad args.

### DIFF
--- a/templates/app/routes/users.js
+++ b/templates/app/routes/users.js
@@ -520,7 +520,13 @@ router.post('/:user/:address/contract/:contractName/:contractAddress/call', json
 
       if(contract.state[method] != undefined){
         console.log("args: " + JSON.stringify(args))
-        var contractstate = contract.state[method](args).txParams(txParams);
+        try {
+          var contractstate = contract.state[method](args).txParams(txParams);
+        } catch (error){
+          console.log("failed to look at state for contract: " + error)
+          res.send("failed to look at state for contract: " + error)
+          return;
+        }
 
         if(privkeyFrom.token){
           console.log("Putting transaction in /pending")


### PR DESCRIPTION
```test · 120461499_import-syntax± ⟩ ./node_modules/mocha/bin/mocha issues/125983817_BadArgName.test.js
config file: config.yaml
{ apiDebug: false,
  password: '1234',
  timeout: 20000,
  nodes:
   [ { id: 0,
       blocUrl: 'http://0.0.0.0:8001',
       explorerUrl: 'http://tester4.centralus.cloudapp.azure.com:9000',
       stratoUrl: 'http://localhost:80' },
     { id: 1,
       explorerUrl: 'http://tester4.centralus.cloudapp.azure.com:9000',
       stratoUrl: 'http://tester4.centralus.cloudapp.azure.com:80',
       blocUrl: 'http://tester4.centralus.cloudapp.azure.com:8000' },
     { id: 2,
       explorerUrl: 'http://tester4.centralus.cloudapp.azure.com:9000',
       stratoUrl: 'http://tester4.centralus.cloudapp.azure.com:80',
       blocUrl: 'http://tester4.centralus.cloudapp.azure.com:8000' } ] }


  125983817_BadArgName
    ✓ should check services availability (83ms)
    ✓ should create user Alice_68699_9355521669 (1265ms)
    ✓ should import and upload a contract fixtures/SimpleStorage.sol (1209ms)
    ✓ should have a valid contract address
    ✓ should check the state of SimpleStorage
    ✓ should have a valid contract state
data string transaction returned: null
    ✓ should call a method {"method":"set","args":{"x":17}} (838ms)
    ✓ should return null (success)
data string failed to look at state for contract: Solidity: function "set" arguments must include "x"
Rejected with message:  Error: Method call returned bad value. "failed to look at state for contract: Solidity: function \"set\" arguments must include \"x\""
    at /Users/kejace/devel/blockapps/strato/deployments/test/lib/api.js:37:14
    at rfc2616Method (/Users/kejace/devel/blockapps/strato/deployments/test/lib/api.js:32:10)
    at process._tickCallback (internal/process/next_tick.js:103:7)
    ✓ should reject an unknown arg name (not crash) (145ms)


  9 passing (4s)```