### PR TITLE
parse string for users to not contain relative path in windows

### DIFF
--- a/templates/app/lib/contract-helpers.js
+++ b/templates/app/lib/contract-helpers.js
@@ -17,7 +17,13 @@ var getContents = function(file, cb) {
 };
 
 var getPath = function(file, cb) {
-  cb(null,file.relative);
+  if(file.relative.includes('\\')) {
+    var index = file.relative.lastIndexOf('\\');
+    var val = file.relative.slice(index+1);
+    cb(null,val);
+  } else {
+    cb(null,file.relative);
+  }
 };
 
 // var getDir = function(file, cb) {


### PR DESCRIPTION
small fix so windows users can use bloc